### PR TITLE
Improved ci and badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
-sudo: false
 language: node_js
+sudo: false
 node_js:
-  - 'iojs'
   - '0.12'
   - '0.10'
+  - '4'
+  - '5'
+
+cache:
+  directories:
+  - node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha ; cat ./coverage/lcov.info | coveralls"
   },
   "files": [
     "index.js"
@@ -36,6 +37,8 @@
     "text"
   ],
   "devDependencies": {
+    "coveralls": "^2.11.6",
+    "istanbul": "^0.4.1",
     "mocha": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,9 @@
-# ansi-256-colors [![Build Status](https://travis-ci.org/jbnicolai/ansi-256-colors.svg?branch=master)](https://travis-ci.org/jbnicolai/ansi-256-colors)
+# ansi-256-colors
+
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Coverage Status][coveralls-badge]][coveralls-status]
+[![Dependency Status][david-badge]][david-url]
 
 > [256 ansi color codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) for styling terminal output
 
@@ -56,3 +61,12 @@ Closes any previously opened color codes.
 ## License
 
 MIT © [Joshua Boy Nicolai Appelman](http://jbnicolai.com)
+
+[npm-badge]: https://badge.fury.io/js/ansi-256-colors.svg
+[npm-url]: https://badge.fury.io/js/ansi-256-colors
+[travis-badge]: https://api.travis-ci.org/jbnicolai/ansi-256-colors.svg
+[travis-url]: https://travis-ci.org/jbnicolai/ansi-256-colors
+[coveralls-badge]:https://coveralls.io/repos/jbnicolai/ansi-256-colors/badge.svg?branch=master&service=github
+[coveralls-url]: https://coveralls.io/github/jbnicolai/ansi-256-colors?branch=master
+[david-badge]: https://david-dm.org/jbnicolai/ansi-256-colors.svg
+[david-url]: https://david-dm.org/jbnicolai/ansi-256-colors


### PR DESCRIPTION
- test for new node version
- add coverage (coveralls for repo to be activated)
- Badges: to know latest avilable verison on npm)

note: I tagged v1.1.0 that was missing
